### PR TITLE
Update genetic code properties, configuration, and interface handling

### DIFF
--- a/egpcommon/egpcommon/properties.py
+++ b/egpcommon/egpcommon/properties.py
@@ -42,7 +42,7 @@ PROPERTIES_CONFIG = {
         "start": 0,
         "width": 2,
         "default": 0,
-        "valid": {"range": [(2,)]},
+        "valid": {"range": [(3,)]},
         "description": ("GC type."),
     },
     "graph_type": {

--- a/egpdb/egpdb/configuration.py
+++ b/egpdb/egpdb/configuration.py
@@ -35,7 +35,7 @@ class DatabaseConfig(Validator, DictTypeAccessor):
     def __init__(
         self,
         dbname: str = "erasmus_db",
-        host: str = "postgres",
+        host: str = "localhost",
         password: str = "/run/secrets/db_password",
         port: int = 5432,
         maintenance_db: str = "postgres",

--- a/egppy/egppy/genetic_code/interface.py
+++ b/egppy/egppy/genetic_code/interface.py
@@ -16,7 +16,7 @@ from egppy.genetic_code.c_graph_constants import (
     Row,
     SrcRow,
 )
-from egppy.genetic_code.end_point import EndPoint
+from egppy.genetic_code.end_point import EndPoint, TypesDef
 
 # Standard EGP logging pattern
 _logger: Logger = egp_logger(name=__name__)
@@ -83,16 +83,20 @@ class Interface(FreezableObject):
     __slots__ = ("endpoints", "_hash")
 
     def __init__(
-        self, endpoints: Sequence[EndPoint] | Sequence[list | tuple], row: Row | None = None
+        self,
+        endpoints: Sequence[EndPoint] | Sequence[list | tuple] | Sequence[str | int | TypesDef],
+        row: Row | None = None,
     ) -> None:
         """Initialize the Interface class.
 
         Args
         ----
-        endpoints: Sequence[EndPoint] | Sequence[Sequence]: A sequence of EndPoint objects or
+        endpoints: Sequence[...]: A sequence of EndPoint objects or
             sequences that define the interface. If a sequence of sequences is provided, each
             inner sequence should contain [ref_row, ref_idx, typ] and the row parameter must
-            be != None.
+            be != None. If a sequence of (mixed) strings, integers or TypesDef is provided,
+            they will be treated as EGP types, in order, as destinations on the row specified unless
+            the row can only be a source.
         row: Row | None: The destination row associated with the interface. Ignored if endpoints are
             provided as EndPoint objects.
         frozen: bool: If True, the object will be frozen after initialization.
@@ -102,6 +106,9 @@ class Interface(FreezableObject):
         self.endpoints: list[EndPoint] | tuple[EndPoint, ...] = []
 
         # Validate row if endpoints are provided as sequences
+        row_cls = (
+            EndPointClass.DST if row is None or row in DESTINATION_ROW_SET else EndPointClass.SRC
+        )
         for idx, ep in enumerate(endpoints):
             if isinstance(ep, EndPoint):
                 if ep.idx != idx:
@@ -110,9 +117,13 @@ class Interface(FreezableObject):
             elif isinstance(ep, (list, tuple)):
                 if len(ep) != 3:
                     raise ValueError(f"Invalid endpoint sequence length: {len(ep)} != 3")
-                if row is None:
-                    raise ValueError("Destination row must be specified if using sequence format.")
+                if row is None or row_cls == EndPointClass.SRC:
+                    raise ValueError("Destination row must be specified if using triplet format.")
                 self.endpoints.append(EndPoint(row=row, idx=idx, cls=EndPointClass.DST, typ=ep[2]))
+            elif isinstance(ep, (str, int, TypesDef)):
+                if row is None:
+                    raise ValueError("Row must be specified if using EGP types.")
+                self.endpoints.append(EndPoint(row=row, idx=idx, cls=row_cls, typ=ep))
             else:
                 raise ValueError(
                     f"Invalid endpoint type: {type(ep)} was expecting EndPoint or Sequence"

--- a/egppy/egppy/genetic_code/interface.py
+++ b/egppy/egppy/genetic_code/interface.py
@@ -117,8 +117,10 @@ class Interface(FreezableObject):
             elif isinstance(ep, (list, tuple)):
                 if len(ep) != 3:
                     raise ValueError(f"Invalid endpoint sequence length: {len(ep)} != 3")
-                if row is None or row_cls == EndPointClass.SRC:
-                    raise ValueError("Destination row must be specified if using triplet format.")
+                if row is None or row not in DESTINATION_ROW_SET:
+                    raise ValueError(
+                        "A valid destination row must be specified (row in DESTINATION_ROW_SET) if using triplet format."
+                    )
                 self.endpoints.append(EndPoint(row=row, idx=idx, cls=EndPointClass.DST, typ=ep[2]))
             elif isinstance(ep, (str, int, TypesDef)):
                 if row is None:

--- a/egppy/egppy/populations/configuration.py
+++ b/egppy/egppy/populations/configuration.py
@@ -8,9 +8,9 @@ from uuid import UUID
 from egpcommon.common import DictTypeAccessor
 from egpcommon.egp_log import CONSISTENCY, DEBUG, VERIFY, Logger, egp_logger
 from egpcommon.validator import Validator
-
-from egppy.genetic_code.interface import Interface
+from egppy.genetic_code.c_graph_constants import DstRow, SrcRow
 from egppy.genetic_code.end_point import EndPoint
+from egppy.genetic_code.interface import Interface, TypesDef
 
 # Standard EGP logging pattern
 _logger: Logger = egp_logger(name=__name__)
@@ -21,8 +21,7 @@ _LOG_CONSISTENCY: bool = _logger.isEnabledFor(level=CONSISTENCY)
 
 # Locally uniquie population id generator
 _POPULATION_IDS: count = count(start=1, step=1)
-INITIAL_POPULATION_SOURCES = (
-    "BEST", "DIVERSE", "RELATED", "UNRELATED", "SPONTANEOUS")
+INITIAL_POPULATION_SOURCES = ("BEST", "DIVERSE", "RELATED", "UNRELATED", "SPONTANEOUS")
 UNDERFLOW_OPTIONS = INITIAL_POPULATION_SOURCES + ("NEXT", "NONE")
 
 
@@ -65,8 +64,7 @@ class SourceConfig(Validator, DictTypeAccessor):
         - {'sse_limit', 'tolerence', 'min_generation', 'max_generation'}  # SPONTANEOUS
         """
         if self.source == "BEST":
-            assert len(
-                kwargs) == 0, f"Additional keys not allowed for BEST. {kwargs} specified."
+            assert len(kwargs) == 0, f"Additional keys not allowed for BEST. {kwargs} specified."
         elif self.source == "DIVERSE":
             assert len(kwargs) == 3, "Invalid number of keys for DIVERSE."
             assert "minimum_distance" in kwargs, "Missing minimum_distance key."
@@ -392,11 +390,11 @@ class PopulationConfig(Validator, DictTypeAccessor):
 
     @inputs.setter
     def inputs(
-        self, value: Sequence[EndPoint] | Sequence[list | tuple]
+        self, value: Sequence[EndPoint] | Sequence[list | tuple] | Sequence[str | int | TypesDef]
     ) -> None:
         """The inputs."""
         self._is_sequence("inputs", value)
-        self._inputs = Interface(value)
+        self._inputs = Interface(value, SrcRow.I)
 
     @property
     def outputs(self) -> Interface:
@@ -405,11 +403,11 @@ class PopulationConfig(Validator, DictTypeAccessor):
 
     @outputs.setter
     def outputs(
-        self, value: Sequence[EndPoint] | Sequence[list | tuple]
+        self, value: Sequence[EndPoint] | Sequence[list | tuple] | Sequence[str | int | TypesDef]
     ) -> None:
         """The inputs."""
         self._is_sequence("inputs", value)
-        self._outputs = Interface(value)
+        self._outputs = Interface(value, DstRow.O)
 
     @property
     def name(self) -> str:
@@ -513,8 +511,7 @@ class PopulationConfig(Validator, DictTypeAccessor):
         """The best source."""
         if isinstance(value, dict):
             value = SourceConfig(**value)
-        assert isinstance(
-            value, SourceConfig), "best_source must be a SourceConfig"
+        assert isinstance(value, SourceConfig), "best_source must be a SourceConfig"
         assert value.source == "BEST", f"best_source must be the BEST source but is {value.source}"
         self._best_source = value
 
@@ -528,8 +525,7 @@ class PopulationConfig(Validator, DictTypeAccessor):
         """The diverse source."""
         if isinstance(value, dict):
             value = SourceConfig(**value)
-        assert isinstance(
-            value, SourceConfig), "diverse_source must be a SourceConfig"
+        assert isinstance(value, SourceConfig), "diverse_source must be a SourceConfig"
         assert (
             value.source == "DIVERSE"
         ), f"diverse_source must be the DIVERSE source but is {value.source}"
@@ -545,8 +541,7 @@ class PopulationConfig(Validator, DictTypeAccessor):
         """The related source."""
         if isinstance(value, dict):
             value = SourceConfig(**value)
-        assert isinstance(
-            value, SourceConfig), "related_source must be a SourceConfig"
+        assert isinstance(value, SourceConfig), "related_source must be a SourceConfig"
         assert (
             value.source == "RELATED"
         ), f"related_source must be the RELATED source but is {value.source}"
@@ -562,8 +557,7 @@ class PopulationConfig(Validator, DictTypeAccessor):
         """The unrelated source."""
         if isinstance(value, dict):
             value = SourceConfig(**value)
-        assert isinstance(
-            value, SourceConfig), "unrelated_source must be a SourceConfig"
+        assert isinstance(value, SourceConfig), "unrelated_source must be a SourceConfig"
         assert (
             value.source == "UNRELATED"
         ), f"unrelated_source must be the UNRELATED source but is {value.source}"
@@ -579,8 +573,7 @@ class PopulationConfig(Validator, DictTypeAccessor):
         """The spontaneous source."""
         if isinstance(value, dict):
             value = SourceConfig(**value)
-        assert isinstance(
-            value, SourceConfig), "spontaneous_source must be a SourceConfig"
+        assert isinstance(value, SourceConfig), "spontaneous_source must be a SourceConfig"
         assert (
             value.source == "SPONTANEOUS"
         ), f"spontaneous_source must be the SPONTANEOUS source but is {value.source}"

--- a/egppy/egppy/storage/cache/cacheable_obj.py
+++ b/egppy/egppy/storage/cache/cacheable_obj.py
@@ -99,7 +99,7 @@ class CacheableDict(MutableMapping, CacheableObjMixin, CommonObj, CacheableObjAB
         return super().verify()
 
 
-class CacheableList(MutableSequence, CacheableObjMixin, CacheableObjABC):
+class CacheableList(MutableSequence, CacheableObjMixin, CommonObj, CacheableObjABC):
     """Cacheable List Class.
     The CacheableList uses a builtin list for storage but implements the MutableSequence
     interface to mark the object as dirty when modified. This makes it slightly
@@ -158,7 +158,7 @@ class CacheableList(MutableSequence, CacheableObjMixin, CacheableObjABC):
         return deepcopy(x=self.data)
 
 
-class CacheableTuple(Sequence, CacheableObjMixin, CacheableObjABC):
+class CacheableTuple(Sequence, CacheableObjMixin, CommonObj, CacheableObjABC):
     """Cacheable Tuple Class.
     Cacheable tuple objects cannot be modified so will never mark themseleves dirty.
     However, the dirty() and clean() methods are provided for consistency and can be used
@@ -195,7 +195,7 @@ class CacheableTuple(Sequence, CacheableObjMixin, CacheableObjABC):
         return list(deepcopy(self.data))
 
 
-class CacheableSet(MutableSet, CacheableObjMixin, CacheableObjABC):
+class CacheableSet(MutableSet, CacheableObjMixin, CommonObj, CacheableObjABC):
     """Cacheable Set Class.
     The CacheableSet uses a builtin set for storage but implements the MutableSet
     interface to mark the object as dirty when modified. This makes it slightly

--- a/egppy/egppy/storage/store/db_table_store.py
+++ b/egppy/egppy/storage/store/db_table_store.py
@@ -1,6 +1,5 @@
 """Database Table store module."""
 
-from ast import In
 from typing import Any, Iterator
 
 from egpcommon.egp_log import CONSISTENCY, DEBUG, VERIFY, Logger, egp_logger

--- a/egppy/egppy/worker/gc_store.py
+++ b/egppy/egppy/worker/gc_store.py
@@ -24,7 +24,7 @@ DB_TABLE_CONFIG = TableConfig(
     schema={k: ColumnSchema(**v) for k, v in GGCDict.GC_KEY_TYPES.items() if v},  # type: ignore
     data_file_folder=join(dirname(__file__), "..", "..", "..", "egpdbmgr", "egpdbmgr", "data"),
     data_files=["meta_codons.json", "codons.json"],
-    delete_table=EGP_PROFILE == EGP_DEV_PROFILE,
+    delete_table=False,
     create_db=True,
     create_table=True,
     conversions=GGCDict.CONVERSIONS,

--- a/egpseed/egpseed/generate_codons.py
+++ b/egpseed/egpseed/generate_codons.py
@@ -125,7 +125,8 @@ def generate_codons(write: bool = False) -> None:
             definition.setdefault("inputs", ipts)
             definition.setdefault("outputs", opts)
             new_codon = GGCDict(MethodExpander(name, definition).to_json())
-            assert new_codon.verify(), f"Invalid codon: {name}"
+            if not new_codon.verify():
+                raise ValueError(f"Invalid codon: {name}")
             assert new_codon.consistency(), f"Invalid codon consistency: {name}"
             codon = new_codon.to_json()
             signature = codon["signature"]

--- a/egpseed/egpseed/generate_codons.py
+++ b/egpseed/egpseed/generate_codons.py
@@ -125,7 +125,8 @@ def generate_codons(write: bool = False) -> None:
             definition.setdefault("inputs", ipts)
             definition.setdefault("outputs", opts)
             new_codon = GGCDict(MethodExpander(name, definition).to_json())
-            new_codon.consistency()
+            assert new_codon.verify(), f"Invalid codon: {name}"
+            assert new_codon.consistency(), f"Invalid codon consistency: {name}"
             codon = new_codon.to_json()
             signature = codon["signature"]
             assert isinstance(signature, str), f"Invalid signature type: {type(signature)}"

--- a/tests/test_egpdb/test_raw_table_integration.py
+++ b/tests/test_egpdb/test_raw_table_integration.py
@@ -21,7 +21,7 @@ _logger.addHandler(NullHandler())
 
 _CONFIG = TableConfig(
     **{
-        "database": {"dbname": "test_db"},
+        "database": {"dbname": "test_db", "host": "postgres"},
         "table": "test_table",
         "schema": {
             "name": {"db_type": "VARCHAR", "nullable": True},

--- a/tests/test_egpdb/test_table_integration.py
+++ b/tests/test_egpdb/test_table_integration.py
@@ -18,7 +18,7 @@ _logger.addHandler(NullHandler())
 
 _CONFIG = TableConfig(
     **{
-        "database": {"dbname": "test_db"},
+        "database": {"dbname": "test_db", "host": "postgres"},
         "table": "test_table",
         "schema": {
             "name": {"db_type": "VARCHAR", "nullable": True},

--- a/tests/test_egppy/test_population/test_configuration.py
+++ b/tests/test_egppy/test_population/test_configuration.py
@@ -5,7 +5,8 @@ from typing import Callable
 from unittest import TestCase
 from uuid import UUID, uuid4
 
-from egppy.genetic_code.types_def import types_def_store
+from egppy.genetic_code.c_graph_constants import DstRow, SrcRow
+from egppy.genetic_code.interface import Interface
 from egppy.populations.configuration import PopulationConfig, PopulationsConfig, SourceConfig
 
 
@@ -19,8 +20,7 @@ class TestSourceConfig(TestCase):
 
     def test_init_best(self):
         """Test the initialization of the BEST source."""
-        config = SourceConfig(source="BEST", scope=127,
-                              limit=20, underflow="NEXT")
+        config = SourceConfig(source="BEST", scope=127, limit=20, underflow="NEXT")
         self.assertEqual(config.source, "BEST")
         self.assertEqual(config.scope, 127)
         self.assertEqual(config.limit, 20)
@@ -182,10 +182,8 @@ class TestPopulationConfig(TestCase):
         self.assertEqual(config.uid, 7)
         self.assertEqual(config.problem, bytes.fromhex("1" * 64))
         self.assertIsInstance(config.worker_id, UUID)
-        self.assertEqual(config.inputs, tuple(
-            (types_def_store[x],) for x in ["int", "str", "bool"]))
-        self.assertEqual(config.outputs, tuple(
-            (types_def_store[x],) for x in ["int", "str", "bool"]))
+        self.assertEqual(config.inputs, Interface(["int", "str", "bool"], SrcRow.I))
+        self.assertEqual(config.outputs, Interface(["int", "str", "bool"], DstRow.O))
         self.assertEqual(config.name, "test")
         self.assertEqual(config.description, "test")
         self.assertEqual(config.meta_data, '{"test": "test"}')

--- a/tests/test_egppy/test_storage/test_store/test_db_table_store.py
+++ b/tests/test_egppy/test_storage/test_store/test_db_table_store.py
@@ -7,12 +7,12 @@ from itertools import count
 
 from egpdb.configuration import TableConfig
 from egpdb.database import db_create, db_delete
-
 from egppy.storage.store.db_table_store import DBTableStore
 from egppy.storage.store.storable_obj import StorableDict
 from egppy.storage.store.storable_obj_abc import StorableObjABC
 from egppy.storage.store.store_abc import StoreABC
-from test_egppy.test_storage.test_store.json_file_store_test_base import JSONFileStoreTestBase
+
+from .json_file_store_test_base import JSONFileStoreTestBase
 
 # To uniquely name databases for parallel execution
 # To avoid conflicts with other test modules we just use the range 0 to 999
@@ -21,7 +21,7 @@ _START_DB_COUNTER = 2000
 
 _CONFIG = TableConfig(
     **{
-        "database": {"dbname": f"test_db_{_START_DB_COUNTER}"},
+        "database": {"dbname": f"test_db_{_START_DB_COUNTER}", "host": "postgres"},
         "table": "test_table",
         "schema": {
             "pk": {"db_type": "VARCHAR", "primary_key": True},

--- a/tests/test_egppy/test_storage/test_store/test_in_memory_store.py
+++ b/tests/test_egppy/test_storage/test_store/test_in_memory_store.py
@@ -1,14 +1,17 @@
 """Test case for InMemoryStore class."""
+
 import unittest
+
+from test_egppy.test_storage.store_test_base import DEFAULT_VALUES, StoreTestBase
+
 from egppy.storage.store.in_memory_store import InMemoryStore
-from egppy.storage.store.storable_obj_abc import StorableObjABC
 from egppy.storage.store.storable_obj import StorableDict, StorableList, StorableSet, StorableTuple
-from test_egppy.test_storage.store_test_base import DEFAULT_VALUES
-from test_egppy.test_storage.store_test_base import StoreTestBase
+from egppy.storage.store.storable_obj_abc import StorableObjABC
 
 
 class TestInMemoryStoreStorableDict(StoreTestBase):
     """Test cases for InMemoryStore class with StorableDict."""
+
     store_type = InMemoryStore
     value_type = StorableDict
     value: StorableObjABC = StorableDict(DEFAULT_VALUES[0])
@@ -18,6 +21,7 @@ class TestInMemoryStoreStorableDict(StoreTestBase):
 
 class TestInMemoryStoreStorableList(StoreTestBase):
     """Test cases for InMemoryStore class with StorableList."""
+
     store_type = InMemoryStore
     value_type = StorableList
     value: StorableObjABC = StorableList(DEFAULT_VALUES[0])
@@ -27,6 +31,7 @@ class TestInMemoryStoreStorableList(StoreTestBase):
 
 class TestInMemoryStoreStorableSet(StoreTestBase):
     """Test cases for InMemoryStore class with StorableSet."""
+
     store_type = InMemoryStore
     value_type = StorableSet
     value: StorableObjABC = StorableSet(DEFAULT_VALUES[0])
@@ -36,6 +41,7 @@ class TestInMemoryStoreStorableSet(StoreTestBase):
 
 class TestInMemoryStoreStorableTuple(StoreTestBase):
     """Test cases for InMemoryStore class with StorableTuple."""
+
     store_type = InMemoryStore
     value_type = StorableTuple
     value: StorableObjABC = StorableTuple(DEFAULT_VALUES[0])
@@ -44,8 +50,8 @@ class TestInMemoryStoreStorableTuple(StoreTestBase):
 
 
 class TestInMemoryStoreIntKey(StoreTestBase):
-    """Test cases for InMemoryStore class with integer keys.
-    """
+    """Test cases for InMemoryStore class with integer keys."""
+
     store_type = InMemoryStore
     value_type = StorableList
     value: StorableObjABC = StorableList(DEFAULT_VALUES[0])
@@ -56,5 +62,5 @@ class TestInMemoryStoreIntKey(StoreTestBase):
     key2 = 560
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_egpseed/test_egpseed.py
+++ b/tests/test_egpseed/test_egpseed.py
@@ -1,6 +1,7 @@
 """Test the generate module."""
 
 import unittest
+
 from egpseed.generate_codons import generate_codons
 
 


### PR DESCRIPTION
- Adjusted valid range for genetic code properties from (2,) to (3,).
- Changed default database host in DatabaseConfig from "postgres" to "localhost".
- Enhanced Interface class to accept additional types (str, int, TypesDef) for endpoints.
- Updated PopulationConfig to utilize the new Interface handling for inputs and outputs.
- Modified DBTableStore to improve item retrieval and ensure primary key handling.
- Refined test configurations to specify database host for test cases.